### PR TITLE
Added cards to the reminders list and put sorted them in order of date

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,20 +12,22 @@ const App = () => {
   return (
     <div className="mt-4 container">
       <div className="row">
-        <div className="col">
-          <Link to="/" className="btn btn-primary">
-            Reminders
-          </Link>
+        <div className="col-4">
+          <div className="text-center">
+            <Link to="/tasks" className="btn btn-primary">
+              Reminders
+            </Link>
+          </div>
         </div>
-        <div className="col">
-          <div className="text-right">
-            <Link to="/new" className="btn btn-primary">
+        <div className="col-4">
+          <div className="text-center">
+            <Link to="/" className="btn btn-primary">
               Add Task
             </Link>
           </div>
         </div>
-        <div className="col">
-          <div className="text-right">
+        <div className="col-4">
+          <div className="text-center">
             <Link to="/about" className="btn btn-primary">
               About
             </Link>
@@ -34,8 +36,8 @@ const App = () => {
       </div>
       <div className="mt-4">
         <Routes>
-          <Route path="/" element={<AllTasks />} />
-          <Route path="/new" element={<Form />} />
+          <Route path="/tasks" element={<AllTasks />} />
+          <Route path="/" element={<Form />} />
           <Route path="/about" element={<About />} />
         </Routes>
       </div>

--- a/src/components/all-tasks/all-tasks.tsx
+++ b/src/components/all-tasks/all-tasks.tsx
@@ -10,7 +10,8 @@ import { useRecoilState, useRecoilValue } from "recoil";
 const AllTasks = () => {
   const tasks = useRecoilValue(tasksAtom);
   return (
-    <div>
+    <div className="container">
+      <h1 className="text-center mb-3">All Reminders</h1>
       {tasks.map((task: Task, index: any) => {
         return <TaskComponent task={task} london={"paris"} />;
       })}

--- a/src/components/reminder-form/reminder-form.tsx
+++ b/src/components/reminder-form/reminder-form.tsx
@@ -19,6 +19,10 @@ const Form = () => {
   const [tasks, setTasks] = useRecoilState(tasksAtom);
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>): void => {
+    const removeDash = (str: string) => {
+      const newStr = str.replace(/-/g, "");
+      return newStr;
+    };
     e.preventDefault();
     const newTask: Task = {
       taskName: taskName,
@@ -37,7 +41,10 @@ const Form = () => {
     logger.info("Task form submitted", newTask);
     const newTasks = [...tasks];
     newTasks.push(newTask);
-    setTasks(newTasks);
+    const sortedTasks = newTasks.sort(
+      (a, b) => parseInt(removeDash(a.reminderDate)) - parseInt(removeDash(b.reminderDate))
+    );
+    setTasks(sortedTasks);
   };
 
   const recurringTypes = [

--- a/src/components/task/task.tsx
+++ b/src/components/task/task.tsx
@@ -13,12 +13,20 @@ const TaskComponent = ({
   task: {
     taskName,
     reminderConfig: { customMessage },
+    reminderDate,
   },
 }: TaskComponentProps) => {
   return (
-    <div>
-      <h1>{taskName}</h1>
-      <p>{customMessage}</p>
+    <div className="card bg-light mb-4" style={{ width: "18rem" }}>
+      <div className="card-header">
+        <h2>{taskName}</h2>
+      </div>
+      <div className="card-body">
+        <p>{customMessage}</p>
+        <p>
+          <b>Reminder Date:</b> {reminderDate}
+        </p>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
# Context

The Reminders Route now display reminders in order of date and in cards using bootsrap. 

# Tests

I added tasks in random order and they were always displayed in the order of the date. 

# Screenshots
<img width="846" alt="Screen Shot 2022-03-19 at 1 12 38 PM" src="https://user-images.githubusercontent.com/91080579/159135226-4816aa07-85ca-4695-ae4a-b4a8a8357d26.png">


Attach screenshots, before and after
